### PR TITLE
Change documentation of port number to match fig.yml.

### DIFF
--- a/INSTALLWithDocker.md
+++ b/INSTALLWithDocker.md
@@ -6,33 +6,14 @@ The Vagrant setup in this guide is optional; however you will need to have an en
 
 ### Prerequisites
 
-Before starting you must first install Vagrant.
+Before starting you must first install:
 
-1. [Install Vagrant](https://docs.vagrantup.com/v2/installation/)
-
-### Initialize Vagrant
-
-This guide will use the Ubuntu Trusty 64 bit image, you can utilize other images however they must support both Docker and Fig. To initialize your setup simply run the following command.
-
-    $ vagrant init ubuntu/trusty64
-
-### Enable a private network
-
-To make testing easier you can setup and utilize a private network. This will allow you to access the Runbook web interface by simply typing an IP and port in your browser. To set this up you will need to edit your `Vagrantfile`.
-
-    $ vi Vagrantfile
-
-**Find:**
-
-      # config.vm.network "private_network", ip: "192.168.33.10"
-
-**Uncomment:**
-
-      config.vm.network "private_network", ip: "192.168.33.10"
+* [Vagrant](https://docs.vagrantup.com/v2/installation/)
+* [Virtualbox](https://www.virtualbox.org/wiki/Downloads)
 
 ### Start the vm
 
-Once you are ready you can startup the vm.
+Once Vagrant and Virtualbox are installed, you can startup the vm. Run this command from the directory that contains the `Vagrantfile`:
 
     $ vagrant up
 
@@ -89,7 +70,7 @@ To access the web application you can simply enter the IP of the vm into your br
 
 **Example:**
 
-    http://192.168.33.10:8080
+    http://192.168.33.10:8000
 
 ### Finding the IP
 

--- a/INSTALL_DOCKER.md
+++ b/INSTALL_DOCKER.md
@@ -75,7 +75,7 @@ $ fig rm
 
 ## Accessing the Web Application
 
-To access the web application you can simply enter the IP of the vm into your browser targeting port 8080 - i.e., [http://192.168.33.10:8080](http://192.168.33.10:8080)
+To access the web application you can simply enter the IP of the vm into your browser targeting port 8000 - i.e., [http://192.168.33.10:8000](http://192.168.33.10:8000)
 
 You can find the vm's IP with:
 


### PR DESCRIPTION
I got a local runbook dev environment running on OS X using boot2docker by following the instructions provided. I came across one discrepancy in the port number of the web app referenced in `INSTALL_DOCKER.md` and have a few other questions which I hope will lead to cleaning up the docs a bit.

I believe the correct port number for accessing the web app is `8000`, not `8080` as defined in [fig.yml](https://github.com/asm-products/cloudroutes-service/blob/master/INSTALLWithDocker.md#start-the-vm).

Questions:
* Since the project ships with a [Vagrantfile](https://github.com/asm-products/cloudroutes-service/blob/master/Vagrantfile), when would you ever want to run the `vagrant init` command referenced in the [Initialize Vagrant](https://github.com/asm-products/cloudroutes-service/blob/master/INSTALLWithDocker.md#initialize-vagrant) section of `INSTALLWithDocker.md`?
* Additionally, the networking for the Vagrantfile is already specified so I'm also wondering if you could delete the entire [Enable a private network](https://github.com/asm-products/cloudroutes-service/blob/master/INSTALLWithDocker.md#enable-a-private-network) section in `INSTALLWithDocker.md`?