### PR TITLE
Add Linode server status check.

### DIFF
--- a/src/monitors/checks/linode-status/__init__.py
+++ b/src/monitors/checks/linode-status/__init__.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+######################################################################
+# Cloud Routes Availability Manager: linode-status module
+# ------------------------------------------------------------------
+# This is a module for performing Linode  status checks.
+# This will return true if if the Linode's current status is one
+# of those expected by the monitor, false otherwise. Anything other
+# than 2xx HTTP status from Linode will return false.
+# ------------------------------------------------------------------
+######################################################################
+
+import requests
+
+http_timeout = 5.0
+url = 'https://api.linode.com/'
+
+def check(**kwargs):
+    ''' Perform a Linode info retrieval and check status '''
+    jdata = kwargs['jdata']
+    logger = kwargs['logger']
+    params = {
+        "api_action": "linode.list",
+        "LinodeID": int(redata['data']['linode_id']),
+        "api_key": str(redata['data']['api_key'])
+    }
+    
+    try:
+        req = requests.get(
+            url, timeout=http_timeout, params=params, verify=True)
+    except Exception as e:
+        line = 'linode-status: Reqeust to {0} sent for monitor {1} - ' \
+               'had an exception: {2}'.format(url, jdata['cid'], e)
+        logger.error(line)
+        return False
+
+    if req.status_code < 200 or req.status_code >= 300:
+        line = 'linode-status: Reqeust to {0} sent for monitor {1} - ' \
+               'non-success HTTP code'.format(url, jdata['cid'])
+        logger.warning(line)
+        return False
+
+    # TODO: Add exception handling in case api returns a malformed/unexpected
+    #       json object that does not contain ['DATA'][0]['STATUS'] key.
+    status = req.jsonstatus['DATA'][0]['STATUS']
+    if status in jdata['DATA']['STATUS']:
+        line = 'linode-status: Reqeust to {0} sent for monitor {1} - ' \
+               'Successful'.format(url, jdata['cid'])
+        logger.info(line)
+        return True
+    else:
+        line = 'linode-status: Reqeust to {0} sent for monitor {1} - ' \
+               'Failure'.format(url, jdata['cid'])
+        logger.info(line)
+        return False

--- a/src/monitors/checks/linode-status/__init__.py
+++ b/src/monitors/checks/linode-status/__init__.py
@@ -2,7 +2,7 @@
 ######################################################################
 # Cloud Routes Availability Manager: linode-status module
 # ------------------------------------------------------------------
-# This is a module for performing Linode  status checks.
+# This is a module for performing Linode server status checks.
 # This will return true if if the Linode's current status is one
 # of those expected by the monitor, false otherwise. Anything other
 # than 2xx HTTP status from Linode will return false.

--- a/src/web/monitorforms/linode-status/__init__.py
+++ b/src/web/monitorforms/linode-status/__init__.py
@@ -1,0 +1,41 @@
+######################################################################
+# Cloud Routes Web Application
+# -------------------------------------------------------------------
+# Linode Server Status Check - Forms Class
+######################################################################
+
+from wtforms import TextField, SelectMultipleField
+from wtforms.validators import DataRequired, NumberRange
+from ..datacenter import DatacenterCheckForm
+
+
+class CheckForm(DatacenterCheckForm):
+
+    ''' Class that creates a Linode server status monitor form
+    for the dashboard '''
+
+    choices = [
+        (-2, 'Boot Failed (not in use)'),
+        (-1, 'Being Created'),
+        (0,  'Brand New'),
+        (1,  'Running'),
+        (2,  'Powered Off'),
+        (3,  'Shutting Down (not in use)'),
+        (4,  'Saved to Disk (not in use)')
+    ]
+
+    apikey = TextField(
+        'API Key',
+        validators=[DataRequired(message='API Key is a required field')])
+    linodeid = TextField(
+        'Linode ID#',
+        validators=[DataRequired(message='Linode ID# is a required field'),
+                    NumberRange(min=1, max=None,
+                                message='Linode ID should be a numeric ID number')])
+    status = SelectMultipleField(
+        'Status',
+        choices=choices,
+        validators=[DataRequired(message='Status is a required field')])
+
+if __name__ == '__main__':
+    pass

--- a/src/web/templates/monitors/linode-status.html
+++ b/src/web/templates/monitors/linode-status.html
@@ -1,0 +1,105 @@
+{% include 'base-header.html' %}
+
+
+<div class="container">
+  <div class="row">
+  <p></p>
+    <!-- sidebar -->
+    {% include 'sidebar.html' %}
+    <!-- content -->
+    <div class="col-md-8">
+      <div class="page-header">
+      {% if data['edit'] %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Manage Monitor</h1>
+      {% else %}
+        <h1><i class="fa fa-eye-slash fa-1x"></i> Add Monitor</h1>
+      {% endif %}
+      </div>
+      {% if data['error'] %}
+      <p class="alert alert-danger">{{ data['msg'] }}</p>
+      {% elif data['msg'] and data['error'] == False %}
+      <p class="alert alert-success">{{ data['msg'] }}</p>
+      {% endif %}
+      {% if form.errors %}
+      {% for field, error in form.errors.items() %}
+      {% for msg in error %}
+      <p class="alert alert-danger">{{msg}}</p>
+      {% endfor %}
+      {% endfor %}
+      {% endif %}
+        <div class="panel panel-primary">
+          <div class="panel-heading">
+            <div class="panel-title">
+            Linode: Status of a server
+            </div>
+          </div>
+          <div class="panel-body">
+            <form action="{{ data['url'] }}" method="post" name="tcp-check" target="_self" class="form-horizontal" role="form">
+            {{ form.csrf_token }}
+
+            {% include 'monitors/base.html' %}
+            {% include 'monitors/timer.html' %}
+            {% include 'monitors/datacenter.html' %}
+            <hr>
+                
+                <div class="form-group">
+                <label for="API Key" class="col-sm-4 control-label">API Key</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+                <span class="input-group-btn">
+                  <button type="button" id="linode-status-apikey" class="btn btn-default" rel="popover" data-content="This field contains your Linode API Token. This can be found in the 'my profile' section in your Linode account under the 'API Keys' tab." title="Linode API Token"><i class="fa fa-question"></i></button>
+                </span>
+              {% if data['edit'] %}
+              {{ form.apikey(class_="form-control", value=data['monitor']['data']['apikey']) }}
+              {% else %}
+              {{ form.apikey(class_="form-control", placeholder="API Key") }}
+              {% endif %}
+              </div>
+            </div>
+              </div>
+
+                <div class="form-group">
+                <label for="Linode ID#" class="col-sm-4 control-label">Linode ID#</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+                <span class="input-group-btn">
+                  <button type="button" id="linode-status-linodeid" class="btn btn-default" rel="popover" data-content="This field contains the ID of your Linode server. This is the number assigned to your server when it was created. It may only contains digits." title="Linode ID"><i class="fa fa-question"></i></button>
+                </span>
+              {% if data['edit'] %}
+              {{ form.linodeid(class_="form-control", value=data['monitor']['data']['linodeid']) }}
+              {% else %}
+              {{ form.linodeid(class_="form-control", placeholder="Linode ID#") }}
+              {% endif %}
+              </div>
+            </div>
+              </div>  
+
+                <div class="form-group">
+                <label for="Status" class="col-sm-4 control-label">Status</label>
+            <div class="col-sm-8">
+              <div class="input-group">
+                <span class="input-group-btn">
+                  <button type="button" id="linode-status-server-status" class="btn btn-default" rel="popover" data-content="Specifies which status to expect for your Linode server. You can select multiple statuses." title="Linode Server Status"><i class="fa fa-question"></i></button>
+                </span>
+              {% if data['edit'] %}
+              {{ form.status(class_="multiselect", value=data['monitor']['data']['status']) }}
+              {% else %}
+              {{ form.status(class_="multiselect", placeholder="Status") }}
+              {% endif %}
+              </div>
+            </div>
+              </div>  
+                
+                <p></p>
+                <button type="submit" class="btn btn-primary btn-block">Submit</button>
+            </form>
+          </div>
+        </div>
+      <div class="panel-group" id="accordion">
+
+      </div>
+    </div>
+  </div> <!-- row -->
+</div> <!-- container -->
+
+{% include 'dash-footer.html' %}

--- a/src/web/templates/monitors/linode-status.js
+++ b/src/web/templates/monitors/linode-status.js
@@ -1,0 +1,17 @@
+<script type="text/javascript">
+  $(document).ready(function() {
+    $.each([
+        '#linode-status-apikey',
+        '#linode-status-linodeid',
+        '#linode-status-server-status'
+      ], function(_, value) {
+      $(value).popover({
+        placement: 'auto bottom',
+        container: 'body',
+        trigger: 'click focus'
+      });
+    });
+
+  });
+
+</script>

--- a/src/web/templates/monitors/monitors.html
+++ b/src/web/templates/monitors/monitors.html
@@ -100,6 +100,18 @@
           <!-- End Health Check 8 lines -->
         </div>
 
+      </div> <!-- end row -->
+      <div class="row">
+
+        <div class="col-md-4">
+          <!-- Start Health Check -->
+          <div class="well">
+            <center><a href="" data-target=".cr-mon-linode-modal-lg" data-toggle="modal"><img src="/static/img/buttons/linode-150.png" border=0 class="img-responsive"></a></center>
+            <h4>Linode</h4>
+            <p>Monitor Linode servers.</p>
+          </div>
+          <!-- End Health Check 8 lines -->
+        </div>
 
       </div> <!-- end row -->
 
@@ -456,6 +468,37 @@
             <a href="/dashboard/monitors/digitalocean-snapshot" class="btn btn-primary btn-md btn-block" role="button">Create</a>
           </div>
           </div> -->
+        </div>
+        <!-- End Modal Body -->
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default btn-md" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Start Modal -->
+<div class="modal fade cr-mon-linode-modal-lg" tabindex="-1" role="dialog" aria-labelledby="LinodeModal" aria=hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal"><span aria-hidden="true"><i class="fa fa-close fa-1x"></i></span><span class="sr-only">Close</span></button>
+        <h4 class="modal-title" id="ModalLabel">Linode</h4>
+      </div>
+      <div class="modal-body">
+        <!-- Begin Modal Body -->
+        <div class="row">
+          <div class="col-md-4">
+         <!-- Start Health Check -->
+          <div class="well">
+            <center><img src="/static/img/buttons/linode-150.png" class="img-responsive"></center>
+            <h4>Linode <small>server status</small></h4>
+            <p>Monitor Linode servers for status changes.</p>
+            <a href="/dashboard/monitors/linode-status" class="btn btn-primary btn-md btn-block" role="button">Create</a>
+          </div>
+          <!-- End Health Check 8 lines -->
+          </div>
         </div>
         <!-- End Modal Body -->
       </div>


### PR DESCRIPTION
For bounty: https://assembly.com/runbook/bounties/253

I need some guidance on testing this either manually or adding test code for it. The current state of this pull request is UNTESTED and I'm hoping this will spur conversation on how to test.

Notes:
* I used Digital Ocean droplet status as a template/guide.
* I was unable to find **any** documentation provided by Linode for the meaning of the "STATUS" field in the json response of the [`linode.list` endpoint](https://www.linode.com/api/linode/linode.list). I found two references that more-or-less agree on what the statuses are and I ended up using the text descriptions from the Python library :
  * [Linode Python Bindings](https://github.com/tjfontaine/linode-python/blob/9ee60e8ba0557b68613cf52d8e4a6f926bdc797f/linode/api.py#L386)
  * [Linode Ruby API](https://github.com/incandescent/linode-utils/blob/163842db0c851f5183f80a400215b4012e09d753/lib/linode-utils.rb#L17)
* I could use some guidance on how you'd like to handle error conditions in the monitor. For example, there is definitely the chance of an exception being thrown [in the monitor code](https://github.com/jalessio/cloudroutes-service/compare/asm-products:develop...add_linode_status_monitor?expand=1#diff-630e930faa54fcf17b54f0a3073b8377R44) if the Linode API ever misbehaves, changes, etc. It seems that the [Digital Ocean monitor is subject to the same sort of thing](https://github.com/asm-products/cloudroutes-service/blob/cce850f49b3c3c89a5c96978b181912e603c05b5/src/monitors/checks/digitalocean-status/__init__.py#L42) though so maybe I'm missing something? (perhaps the exceptions are being caught elsewhere in the stack?)