### PR TITLE
BaseReaction class for writing reactions

### DIFF
--- a/src/actions/actions/__init__.py
+++ b/src/actions/actions/__init__.py
@@ -1,0 +1,75 @@
+"""Base Reaction class."""
+
+import time
+
+
+class BaseReaction(object):
+    """Base class for a reaction.
+
+    Actual reactions are supposed to subclass it and override the _Action method
+    at minimum.
+    """
+
+    def __init__(self, **kwargs):
+        self.redata = kwargs['redata']
+        self.jdata = kwargs['jdata']
+        self.rdb = kwargs['rdb']
+        self.r_server = kwargs['r_server']
+        self.config = kwargs['config']
+        self.logger = kwargs['logger']
+
+    def _ShouldRun(self):
+        """Common set of conditions to check if the reaction should be run.
+
+        Note that this is applicable to *most* reactions, but your reaction
+        may have a different set of requirements. If it does, override this
+        method.
+        """
+        return (
+            # Check that we exceeded user specified failcount for the reaction
+            # to trigger.
+            self.jdata['failcount'] >= self.redata['trigger'] and
+            # Check that we don't run the reaction more often than the specified
+            # frequency.
+            (time.time() - float(self.redata['lastrun'])) >= self.redata['frequency'] and
+            # Should the reaction be called when the monitor is True or False?
+            self.redata['data']['call_on'] in self.jdata['check']['status']
+        )
+
+    def Run(self):
+        """Runs a reaction.
+
+        Subclasses MUST NOT override.
+        """
+        if self._ShouldRun():
+            return self._SafeAction()
+
+    def _Action(self):
+        """Actual business logic of the reaction.
+
+        Subclasses MUST override.
+
+        Returns: bool or None
+            True, if the reaction execution was successful.
+            False, if the reaction execution was unsuccessful.
+            None, if the reaction execution was skipped.
+        """
+        raise NotImplementedError()
+
+    def _SafeAction(self):
+        """Wrapper around Action method.
+
+        Catches all exceptions raised by Action and logs them, preventing the
+        module itself to crash.
+
+        Subclasses MUST NOT override.
+        """
+        try:
+            return self._Action()
+        except Exception, e:  #pylint: disable=broad-except
+            self.logger.warning(
+                '{module}: Reaction {id} failed: {message}'.format(
+                    module=self.__module__,
+                    id=self.redata['id'],
+                    message=e.message))
+            return False

--- a/src/actions/actions/twilio-sms-notification/__init__.py
+++ b/src/actions/actions/twilio-sms-notification/__init__.py
@@ -2,38 +2,22 @@
 
 import time
 from twilio.rest import TwilioRestClient
+from .. import BaseReaction
 
 
-def __action(**kwargs):
-    redata = kwargs['redata']
-    jdata = kwargs['jdata']
-    run = (
-        jdata['failcount'] >= redata['trigger'] and
-        (time.time() - float(redata['lastrun'])) >= redata['frequency'] and
-        redata['data']['call_on'] in jdata['check']['status']
-    )
-    if run:
-        account_sid = redata['data']['account_sid']
-        auth_token = redata['data']['auth_token']
-        from_address = redata['data']['from_address']
-        to_address = redata['data']['to_address']
-        text = redata['data']['text']
-        return call_twilio(account_sid, auth_token, from_address, to_address, text)
+class Reaction(BaseReaction):
 
-
-def call_twilio(account_sid, auth_token, from_address, to_address, text):
-    client = TwilioRestClient(account_sid, auth_token)
-    message = client.messages.create(to=to_address,from_=from_address,body=text)
-    assert message.status not in ('failed', 'undelivered'), message.ErrorMessage
-    return True
-
-
-def action(**kwargs):
-    try:
-        return __action(**kwargs)
-    except Exception, e:
-        redata = kwargs['redata']
-        logger = kwargs['logger']
-        logger.warning('twilio-sms-notification: Reaction {id} failed: {message}'.format(
-            id=redata['id'], message=e.message))
-        return False
+    def _Action(self):
+        account_sid = self.redata['data']['account_sid']
+        auth_token = self.redata['data']['auth_token']
+        from_address = self.redata['data']['from_address']
+        to_address = self.redata['data']['to_address']
+        text = self.redata['data']['text']
+        client = TwilioRestClient(account_sid, auth_token)
+        message = client.messages.create(
+            to=to_address,
+            from_=from_address,
+            body=text)
+        assert message.status not in ('failed', 'undelivered'), \
+            message.ErrorMessage
+        return True


### PR DESCRIPTION
New reactions can simply subclass it and override the _Action method to
write the business logic of the reaction. Other surrounding logic like
whether to run the reaction or not or error handling etc. are taken
care of by the base class.

Obvious benefits include that by making the BaseReaction class more
robust over the time, all other reactions also become more robust.
Furthermore, similar reactions like AmazonEC2 reactions can have an
intermediate subclass which can encapsulate EC2 specific logic.

Migrated Twilio SMS notification reaction to the new style as a proof
of concept.