### PR TITLE
Updated assembly banner with our custom Open Sans font

### DIFF
--- a/src/web/static/css/custom.css
+++ b/src/web/static/css/custom.css
@@ -28,3 +28,7 @@
   color: #fff;
   text-decoration: none;
 }
+
+.dash-footer .credit .assembly-link {
+  color: #666;
+}

--- a/src/web/static/css/home.css
+++ b/src/web/static/css/home.css
@@ -1,7 +1,7 @@
 /* Overwrite defaults */
 @import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700);
 body {
-	background-color: #fff;
+	background-color: #faf8fa;
   font-family: "Open Sans", "Helvetica", sans-serif;
   font-weight: 400;
 }
@@ -281,11 +281,11 @@ body {
   text-shadow: 0px 1px 2px rgba(0,0,0,0.8);
 }
 
-.footer-action-section h5 a {
-  color: #4FC6ED;
+.assembly-link, .assembly-link:hover {
+  color: #fff;
+  font-weight: 500;
 }
 
-.footer-action-section h5 a:hover {
-  color: #fff;
-  text-decoration: underline;
+.assembly-link i {
+  color: #f23354;
 }

--- a/src/web/templates/dash-footer.html
+++ b/src/web/templates/dash-footer.html
@@ -1,8 +1,8 @@
-  <div class="container">
+  <div class="dash-footer container">
     <div class="row">
      <div class="col-lg-12">
       <hr>
-       <p class="text-muted credit text-right">Runbook &copy; is a <a href="https://assembly.com/runbook" target="_blank">Assembly</a> project, All Rights Reserved.</p>
+      <p class="text-muted credit text-right">Runbook &copy; is <a href="https://assembly.com/runbook?utm_campaign=assemblage&utm_source=runbook&utm_medium=flair_widget&utm_content=light_banner" class="assembly-link">Build with <i class="glyphicon glyphicon-heart"></i> on Assembly</a>. All Rights Reserved.</p>
     </div>
    </div>
   </div>

--- a/src/web/templates/public/index.html
+++ b/src/web/templates/public/index.html
@@ -141,7 +141,7 @@
 
     <a href="https://dash.runbook.io/signup" class="btn btn-action call-to-action">Get Started Now</a>
 
-    <h5>Runbook is open source and built with <3 on <a href="https://assembly.com/runbook" target="_blank">Assembly</a>.</h5>
+    <h5>Runbook is <a href="https://assembly.com/runbook?utm_campaign=assemblage&utm_source=runbook&utm_medium=flair_widget&utm_content=light_banner" class="assembly-link">Built with <i class="glyphicon glyphicon-heart"></i> on Assembly</a></h5>
 
   </div>
 </div>


### PR DESCRIPTION
Updated the `footer-action-section` at the Landing Page with a custom version of Assembly badge with their custom Google Analytics campaing url.

Added the custom version of Assembly badge to the `dash-footer` too, updating all the pages with the new badge.

I customized the badge because in our branding we use the **Open Sans** font for all the pages, and the **Helvetica Neue** used by Assembly was presenting too much contrast in weight.

I think that will not present a problem with them. I kept all the other details that they use for their badge only changing the font style.